### PR TITLE
Reset search-input cursor on upwards navigation

### DIFF
--- a/src/components/SearchInput.vue
+++ b/src/components/SearchInput.vue
@@ -3,6 +3,7 @@
     
     <div class="search">
       <input
+        ref="input"
         type="text"
         placeholder="Search for a movie or show"
         autocorrect="off"
@@ -93,6 +94,13 @@ export default {
     navigateUp() {
       this.focus = true
       this.selectedResult--
+      const input = this.$refs.input;
+      const textLength = input.value.length
+
+      setTimeout(() => {
+        input.focus()
+        input.setSelectionRange(textLength, textLength + 1)
+      }, 1)
     },
     handleInput(e){
       this.selectedResult = 0


### PR DESCRIPTION
When navigating up in the autocomplete search result list the cursor usually reset back to the start of the input. Now we get the element and use focus and setSelectionRange to move the cursor back to the end at the very next frame.