### PR TITLE
Disable scroll on content behind popover movie view

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -123,6 +123,10 @@ img{
   height: auto;
 }
 
+.no-scroll {
+  overflow: hidden;
+}
+
 .wrapper{
   position: relative;
 }

--- a/src/components/MoviePopup.vue
+++ b/src/components/MoviePopup.vue
@@ -32,9 +32,11 @@ export default {
   },
   created(){
     window.addEventListener('keyup', this.checkEventForEscapeKey)
+    document.getElementsByTagName("body")[0].classList += " no-scroll";
   },
   beforeDestroy() {
     window.removeEventListener('keyup', this.checkEventForEscapeKey)
+    document.getElementsByTagName("body")[0].classList.remove("no-scroll");
   }
 
 }


### PR DESCRIPTION
When movie popup opens we add a no-scroll class to the body element. This prevents scrolling the content behind the popover content.

This resolves #30