### PR TITLE
Fix: Search query reload

### DIFF
--- a/src/pages/SearchPage.vue
+++ b/src/pages/SearchPage.vue
@@ -12,7 +12,12 @@
       </div>
     </div>
 
-    <ResultsSection v-if="query" :title="title" :api-function="search" />
+    <ResultsSection
+      :key="query"
+      v-if="query"
+      :title="title"
+      :api-function="search"
+    />
     <h1 v-else class="no-results">No query found, please search above</h1>
   </div>
 </template>

--- a/src/pages/SearchPage.vue
+++ b/src/pages/SearchPage.vue
@@ -13,8 +13,8 @@
     </div>
 
     <ResultsSection
-      :key="query"
       v-if="query"
+      :key="query"
       :title="title"
       :api-function="search"
     />

--- a/src/pages/SearchPage.vue
+++ b/src/pages/SearchPage.vue
@@ -18,7 +18,7 @@
 </template>
 
 <script setup lang="ts">
-  import { ref, computed } from "vue";
+  import { ref, computed, watch } from "vue";
   import { useRoute, useRouter } from "vue-router";
 
   import ResultsSection from "@/components/ResultsSection.vue";
@@ -45,12 +45,14 @@
 
   const title = computed(() => `Search results: ${query.value}`);
 
-  const urlQuery = route.query;
-  if (urlQuery && urlQuery?.query) {
-    query.value = decodeURIComponent(urlQuery?.query?.toString());
-    page.value = Number(urlQuery?.page) || 1;
-    adult.value = Boolean(urlQuery?.adult) || adult.value;
-    mediaType.value = (urlQuery?.media_type as MediaTypes) || mediaType.value;
+  function readQueryParams() {
+    const urlQuery = route.query;
+    if (urlQuery && urlQuery?.query) {
+      query.value = decodeURIComponent(urlQuery?.query?.toString());
+      page.value = Number(urlQuery?.page) || 1;
+      adult.value = Boolean(urlQuery?.adult) || adult.value;
+      mediaType.value = (urlQuery?.media_type as MediaTypes) || mediaType.value;
+    }
   }
 
   const search = (
@@ -73,6 +75,12 @@
   function toggleChanged() {
     updateQueryParams();
   }
+
+  readQueryParams();
+  watch(
+    () => route.fullPath,
+    () => readQueryParams()
+  );
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
We re-render content when route changes from `App.vue`, but only on when the path changes. This breaks search page that only changes query parameters for same `/search` page.

Now have a watcher on searchPage that gets local variables from query parameters every time the route changes.  
Also needed to key resultsection with query for force re-render whenever query changes. [bcf5b7d](https://github.com/KevinMidboe/seasoned/commit/bcf5b7d890b42de3e41a6ff335c910ab713b3115)